### PR TITLE
Add tests for add/remove token support methods

### DIFF
--- a/tests/test_token_support.py
+++ b/tests/test_token_support.py
@@ -1,0 +1,20 @@
+def test_token_support(w3, contract, DAI_token, USDC_token, assert_fail):
+    owner = w3.eth.defaultAccount
+    user = w3.eth.accounts[1]
+
+    assert contract.supportedTokens(DAI_token.address)
+    assert contract.supportedTokens(USDC_token.address)
+
+    # sender should be owner
+    assert_fail(lambda: contract.removeTokenSupport(USDC_token.address, transact={'from': user}))
+    assert contract.removeTokenSupport(USDC_token.address, transact={'from': owner})
+    assert not contract.supportedTokens(USDC_token.address)
+
+    # can't remove unsupported token
+    assert_fail(lambda: contract.removeTokenSupport(USDC_token.address, transact={'from': owner}))
+    # can't add supported token
+    assert_fail(lambda: contract.addTokenSupport(DAI_token.address, transact={'from': owner}))
+
+    assert_fail(lambda: contract.addTokenSupport(USDC_token.address, transact={'from': user}))
+    assert contract.addTokenSupport(USDC_token.address, transact={'from': owner})
+    assert contract.supportedTokens(USDC_token.address)


### PR DESCRIPTION
resolves [Ability to add / remove stablecoin support](https://www.pivotaltracker.com/story/show/163503704)

I guess it's possible scenario if owner removes token support and then user wants to remove liquidity more than balance of remaining tokens. For example:
- we have 10 DAI and 5 USDC (15 USD total)
- two users have 0.5 ownership (7.5 USD each)
- owner removes DAI support
- user wants to remove his liquidity (7.5 USD) but we have 5 USDC only

What should we do in this case?