### PR TITLE
Use List instead of Mapping for input/output tokens

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,8 +73,14 @@ def USDC_token(w3):
     return contract
 
 @pytest.fixture
-def contract(w3, DAI_token, USDC_token):
-    available_tokens = [DAI_token.address, USDC_token.address, DAI_token.address]
+def TUSD_token(w3):
+    args = [b'TUSD Test Token', b'TUSD', 18, 100000*10**18]
+    contract = create_contract(w3, 'tests/support/ERC20.vy', *args)
+    return contract
+
+@pytest.fixture
+def contract(w3, DAI_token, USDC_token, TUSD_token):
+    available_tokens = [DAI_token.address, USDC_token.address, TUSD_token.address]
     contract = create_contract(w3, 'contracts/stablecoinswap.vy', *[available_tokens])
     return contract
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -5,13 +5,13 @@ from tests.constants import (
     ZERO_ADDR
 )
 
-def test_contract(w3, contract, DAI_token, pad_bytes32):
+def test_contract(w3, contract, DAI_token, USDC_token):
   assert contract.owner() == w3.eth.defaultAccount
   assert contract.name() == b'Stablecoinswap'
   assert contract.decimals() == 18
   assert contract.totalSupply() == 0
   # check used tokens
-  assert contract.inputTokens(DAI_token.address)
-  assert not contract.inputTokens(w3.eth.accounts[1])
-  assert contract.outputTokens(DAI_token.address)
-  assert not contract.outputTokens(w3.eth.accounts[1])
+  assert DAI_token.address in contract.availableInputTokens()
+  assert not w3.eth.accounts[1] in contract.availableInputTokens()
+  assert USDC_token.address in contract.availableOutputTokens()
+  assert not w3.eth.accounts[1] in contract.availableOutputTokens()

--- a/tests/test_swap_tokens.py
+++ b/tests/test_swap_tokens.py
@@ -16,8 +16,8 @@ def test_swap_tokens(w3, contract, DAI_token, USDC_token, assert_fail):
     USDC_token.transfer(w3.eth.defaultAccount, USDC_ADDED, transact={})
     USDC_token.approve(contract.address, USDC_ADDED, transact={'from': w3.eth.defaultAccount})
 
-    assert contract.inputTokens(DAI_token.address)
-    assert contract.outputTokens(USDC_token.address)
+    assert DAI_token.address in contract.availableInputTokens()
+    assert USDC_token.address in contract.availableOutputTokens()
     # we don't have enough output tokens
     assert_fail(lambda: contract.swapTokens(DAI_token.address, USDC_token.address, INPUT_AMOUNT, PRICE_LIMIT, DEADLINE, transact={'from': user_address}))
 

--- a/tests/test_token_support.py
+++ b/tests/test_token_support.py
@@ -2,13 +2,13 @@ def test_update_input_token(w3, contract, DAI_token, USDC_token, assert_fail):
     owner = w3.eth.defaultAccount
     user = w3.eth.accounts[1]
 
-    assert contract.inputTokens(DAI_token.address)
-    assert contract.inputTokens(USDC_token.address)
+    assert DAI_token.address in contract.availableInputTokens()
+    assert USDC_token.address in contract.availableInputTokens()
 
     # sender should be owner
     assert_fail(lambda: contract.updateInputToken(USDC_token.address, False, transact={'from': user}))
     assert contract.updateInputToken(USDC_token.address, False, transact={'from': owner})
-    assert not contract.inputTokens(USDC_token.address)
+    assert not USDC_token.address in contract.availableInputTokens()
 
     # can't remove unsupported token
     assert_fail(lambda: contract.updateInputToken(USDC_token.address, False, transact={'from': owner}))
@@ -17,19 +17,19 @@ def test_update_input_token(w3, contract, DAI_token, USDC_token, assert_fail):
 
     assert_fail(lambda: contract.updateInputToken(USDC_token.address, True, transact={'from': user}))
     assert contract.updateInputToken(USDC_token.address, True, transact={'from': owner})
-    assert contract.inputTokens(USDC_token.address)
+    assert USDC_token.address in contract.availableInputTokens()
 
 def test_update_output_token(w3, contract, DAI_token, USDC_token, assert_fail):
     owner = w3.eth.defaultAccount
     user = w3.eth.accounts[1]
 
-    assert contract.outputTokens(DAI_token.address)
-    assert contract.outputTokens(USDC_token.address)
+    assert DAI_token.address in contract.availableOutputTokens()
+    assert USDC_token.address in contract.availableOutputTokens()
 
     # sender should be owner
     assert_fail(lambda: contract.updateOutputToken(USDC_token.address, False, transact={'from': user}))
     assert contract.updateOutputToken(USDC_token.address, False, transact={'from': owner})
-    assert not contract.outputTokens(USDC_token.address)
+    assert not USDC_token.address in contract.availableOutputTokens()
 
     # can't remove unsupported token
     assert_fail(lambda: contract.updateOutputToken(USDC_token.address, False, transact={'from': owner}))
@@ -38,4 +38,4 @@ def test_update_output_token(w3, contract, DAI_token, USDC_token, assert_fail):
 
     assert_fail(lambda: contract.updateOutputToken(USDC_token.address, True, transact={'from': user}))
     assert contract.updateOutputToken(USDC_token.address, True, transact={'from': owner})
-    assert contract.outputTokens(USDC_token.address)
+    assert USDC_token.address in contract.availableOutputTokens()


### PR DESCRIPTION
resolves [Use List instead of Mapping for input/output tokens](https://www.pivotaltracker.com/story/show/163671335)

- we can't call contract variables like `contract.inputTokens()` due it requires `index` as argument. So to get whole tokens list I've added `availableInputTokens` and `availableOutputTokens` functions. There I declared that these functions don't require arguments.
- large `MAX_TOKENS` value raises 'OutOfGas' exception. I tried to research it and found that max value to not raise this exception is 433 for current contract implementation. But I guess this number will be less in further when we add more code to contract. So I set it to 100.
- I got `IndexError: pop from empty list` error for `findElementIndex(list: address[MAX_TOKENS], _address: address)`. I guess it is caused by empty values in `inputTokens` and `outputTokens`. When we use list with empty values as argument it raises an error. To solve it I split `findElementIndex` and `indexOfFirstEmptyElement` for `inputTokens` and `outputTokens`. It allows as to not use tokens list as method argument.