### PR TITLE
Add ability to pause contract functions

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,20 @@
+def test_permissions(w3, contract, assert_fail):
+  owner = w3.eth.defaultAccount
+  user = w3.eth.accounts[1]
+
+  # after initialization
+  assert contract.permissions(b'liquidityAddingAllowed')
+  assert contract.permissions(b'liquidityRemovingAllowed')
+  assert contract.permissions(b'tradingAllowed')
+
+  contract.updatePermission(b'liquidityAddingAllowed', False, transact={'from': owner})
+  assert not contract.permissions(b'liquidityAddingAllowed')
+
+  # only owner can change permission
+  assert_fail(lambda: contract.updatePermission(b'liquidityRemovingAllowed', False, transact={'from': user}))
+  contract.updatePermission(b'liquidityRemovingAllowed', False)
+  assert contract.permissions(b'liquidityRemovingAllowed')
+
+  # after permission was disabled it's possible to enable it again
+  contract.updatePermission(b'liquidityAddingAllowed', True, transact={'from': owner})
+  assert contract.permissions(b'liquidityAddingAllowed')

--- a/tests/test_swap_tokens.py
+++ b/tests/test_swap_tokens.py
@@ -42,3 +42,7 @@ def test_swap_tokens(w3, contract, DAI_token, USDC_token, assert_fail):
     contract.updateOutputToken(USDC_token.address, True, transact={'from': w3.eth.defaultAccount})
     contract.updateInputToken(DAI_token.address, False, transact={'from': w3.eth.defaultAccount})
     assert_fail(lambda: contract.swapTokens(DAI_token.address, USDC_token.address, INPUT_AMOUNT, PRICE_LIMIT, DEADLINE, transact={'from': user_address}))
+    contract.updateInputToken(DAI_token.address, True, transact={'from': w3.eth.defaultAccount})
+    # permissions['tradingAllowed'] should be True
+    contract.updatePermission(b'tradingAllowed', False, transact={'from': w3.eth.defaultAccount})
+    assert_fail(lambda: contract.swapTokens(DAI_token.address, USDC_token.address, INPUT_AMOUNT, PRICE_LIMIT, DEADLINE, transact={'from': user_address}))


### PR DESCRIPTION
resolves [Ability to pause contract functions](https://www.pivotaltracker.com/story/show/163503700)

The issue was caused by omitting `msg.sender`:
```
contract.updatePermission(b'liquidityRemovingAllowed', False)
```
This code doesn't change permission due `msg.sender` is unknown. At the same time it doesn't raise an exception like this code:
```
contract.updatePermission(b'liquidityRemovingAllowed', False, transact={'from': user})
```
