### PR TITLE
normalized token prices

### DIFF
--- a/tests/test_liquidity_pool.py
+++ b/tests/test_liquidity_pool.py
@@ -47,7 +47,7 @@ def test_add_liquidity(w3, contract, DAI_token, USDC_token, price_oracle, assert
     DAI_PRICE = 1
     USDC_PRICE = Decimal('1.2')
     price_oracle.updatePrice(DAI_token.address, DAI_PRICE * 10**8, transact={'from': owner})
-    price_oracle.updatePrice(USDC_token.address, int(USDC_PRICE * 10**8), transact={'from': owner})
+    price_oracle.updatePrice(USDC_token.address, int(USDC_PRICE * 10**8 * 10**12), transact={'from': owner})
     price_oracle.updateTokenAddress(DAI_token.address, 0, transact={'from': owner})
     price_oracle.updateTokenAddress(USDC_token.address, 1, transact={'from': owner})
 
@@ -106,7 +106,7 @@ def test_liquidity_pool(w3, contract, DAI_token, USDC_token, price_oracle, asser
     USDC_token.transfer(user2, 42*10**6, transact={})
     USDC_token.approve(contract.address, 42*10**6, transact={'from': user2})
     USDC_ADDED = 30 * 10**6 # 30 USDC
-    price_oracle.updatePrice(USDC_token.address, INT_TOKEN_PRICE, transact={'from': owner})
+    price_oracle.updatePrice(USDC_token.address, INT_TOKEN_PRICE * 10**12, transact={'from': owner})
     price_oracle.updateTokenAddress(USDC_token.address, 1, transact={'from': owner})
     contract.addLiquidity(USDC_token.address, USDC_ADDED, DEADLINE, transact={'from': user2})
 
@@ -242,7 +242,7 @@ def test_fees(w3, contract, DAI_token, USDC_token, price_oracle, assert_fail):
     USDC_token.transfer(user_usdc, 42*10**6, transact={})
     USDC_token.approve(contract.address, 42*10**6, transact={'from': user_usdc})
     USDC_15 = 15 * 10**6 # 15 USDC
-    price_oracle.updatePrice(USDC_token.address, int(TOKEN_PRICE * 10**8), transact={'from': owner})
+    price_oracle.updatePrice(USDC_token.address, int(TOKEN_PRICE * 10**8 * 10**12), transact={'from': owner})
     price_oracle.updateTokenAddress(USDC_token.address, 1, transact={'from': owner})
 
     tx_hash = contract.addLiquidity(USDC_token.address, USDC_15, DEADLINE, transact={'from': user_usdc})

--- a/tests/test_price_oracle.py
+++ b/tests/test_price_oracle.py
@@ -28,7 +28,7 @@ def test_pool_size(w3, contract, price_oracle, DAI_token, USDC_token, assert_fai
   owner = w3.eth.defaultAccount
 
   price_oracle.updatePrice(DAI_token.address, 2 * 10**8, transact={'from': owner})
-  price_oracle.updatePrice(USDC_token.address, 3 * 10**8, transact={'from': owner})
+  price_oracle.updatePrice(USDC_token.address, 3 * 10**8 * 10**12, transact={'from': owner})
   price_oracle.updateTokenAddress(DAI_token.address, 0, transact={'from': owner})
   price_oracle.updateTokenAddress(USDC_token.address, 1, transact={'from': owner})
 

--- a/tests/test_swap_tokens.py
+++ b/tests/test_swap_tokens.py
@@ -24,7 +24,7 @@ def test_swap_tokens(w3, contract, price_oracle, DAI_token, USDC_token, assert_f
     USDC_token.transfer(w3.eth.defaultAccount, USDC_ADDED, transact={})
     USDC_token.approve(contract.address, USDC_ADDED, transact={'from': owner})
     price_oracle.updatePrice(DAI_token.address, DAI_TOKEN_PRICE, transact={'from': owner})
-    price_oracle.updatePrice(USDC_token.address, USDC_TOKEN_PRICE, transact={'from': owner})
+    price_oracle.updatePrice(USDC_token.address, USDC_TOKEN_PRICE * 10**12, transact={'from': owner})
     price_oracle.updateTokenAddress(DAI_token.address, 0, transact={'from': owner})
     price_oracle.updateTokenAddress(USDC_token.address, 1, transact={'from': owner})
 


### PR DESCRIPTION
Gas usage:
addLiquidity (firts call) 110,657 (was 113,790)
addLiquidity (next one call) 91,316 (was 101,686)
swapToken 101,607 (was 120,201)
removeLiquidity 74,573 (was 89,150).

There is a change related to assert https://github.com/gonchs/stablecoinswap-contracts/blob/6253212b851b8918611a45a4257fb0eaf8201057/contracts/priceoracle.vy#L52

Now MIN_PRICE and MAX_PRICE are not exact prices, but just numbers. If we want to check real prices, then we need ```ERC20.decimals```, but if we will call it in ```updatePrice```, then the cost of every updatePrice transaction will be increased by 2000 gas. But we call it quite often, so I guess it will be an issue.
